### PR TITLE
Fix typo in docstring

### DIFF
--- a/common_regex.py
+++ b/common_regex.py
@@ -1,7 +1,7 @@
 import re
 
 '''
-python regualr expressions utility library
+python regular expressions utility library
 to use this library your strings need to be encoded in utf-8
 '''
 class CommonRegex:


### PR DESCRIPTION
## Summary
- correct spelling typo in the common_regex docstring

## Testing
- `python3 tests.py`

------
https://chatgpt.com/codex/tasks/task_e_683f5612003c832d882b3012dd948295